### PR TITLE
内存优化

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,21 @@
 在项目根目录下，执行以下命令：
 
 ```shell
-./build.sh
+./start-infrastructure.sh         #启动基础设施
+./createdb.sh                     #创建数据库 (注：需要mysql或mariadb命令行支持)
+./migratedb.sh                    #初始化数据库
+./build-application.sh            #编译应用程序
 ```
 
 ## 使用方法
 
-在根目录下启动docker容器：
+在根目录下启动：
 
 ```shell
-docker-compose up --build
+./start-infrastructure.sh         #启动基础设施
+./createdb.sh                     #创建数据库  (注：需要mysql或mariadb命令行支持)
+./migratedb.sh                    #初始化数据库
+./start-application.sh            #启动应用程序
 ```
 
 访问以下地址，通过HAL-Browser查看数据模型，进行增删改查。
@@ -24,15 +30,18 @@ docker-compose up --build
 http://localhost:8080/api
 ```
 
-关闭所有容器：
+停止：
 
 ```shell
-docker-compose down
+./stop-application.sh             #关闭应用程序
+./stop-infrastructure.sh          #关闭基础设施
 ```
 
 ## 已集成组件
 
 mariaDB
+
+kafka/kafka streams
 
 docker/docker-compose
 

--- a/application.yml
+++ b/application.yml
@@ -9,7 +9,6 @@ services:
     ports:
       - 8080:8080
     environment:
-      RESERVED_MEGABYTES: 64
       SPRING_PROFILES_ACTIVE: dev
 
   fund-service:
@@ -20,7 +19,6 @@ services:
     ports:
       - 10010:10010
     environment:
-      RESERVED_MEGABYTES: 64
       SPRING_PROFILES_ACTIVE: dev
 
   inventory-service:
@@ -31,7 +29,6 @@ services:
     ports:
       - 10011:10011
     environment:
-      RESERVED_MEGABYTES: 64
       SPRING_PROFILES_ACTIVE: dev
  
   invest-service:
@@ -42,7 +39,6 @@ services:
     ports:
       - 10012:10012
     environment:
-      RESERVED_MEGABYTES: 64
       SPRING_PROFILES_ACTIVE: dev
 
   trade-service:
@@ -53,5 +49,4 @@ services:
     ports:
       - 10013:10013
     environment:
-      RESERVED_MEGABYTES: 64
       SPRING_PROFILES_ACTIVE: dev

--- a/application.yml
+++ b/application.yml
@@ -4,44 +4,54 @@ services:
   edge-service:
     build: edge-service
     container_name: edge-service
+    mem_limit: 512M
     network_mode: "host"
     ports:
       - 8080:8080
     environment:
+      RESERVED_MEGABYTES: 64
       SPRING_PROFILES_ACTIVE: dev
 
   fund-service:
     build: fund-service
-    command: /bin/bash -c "wait-for-it -t 0 localhost:3306 && java -jar /app/fund-service-latest.jar"
+    command: /bin/bash -c "wait-for-it -t 0 localhost:3306 && /app/start /app/fund-service-latest.jar"
+    mem_limit: 512M
     network_mode: "host"
     ports:
       - 10010:10010
     environment:
+      RESERVED_MEGABYTES: 64
       SPRING_PROFILES_ACTIVE: dev
 
   inventory-service:
     build: inventory-service
-    command: /bin/bash -c "wait-for-it -t 0 localhost:3306 && java -jar /app/inventory-service-latest.jar"
+    command: /bin/bash -c "wait-for-it -t 0 localhost:3306 && /app/start /app/inventory-service-latest.jar"
+    mem_limit: 512M
     network_mode: "host"
     ports:
       - 10011:10011
     environment:
+      RESERVED_MEGABYTES: 64
       SPRING_PROFILES_ACTIVE: dev
  
   invest-service:
     build: invest-service
-    command: /bin/bash -c "wait-for-it -t 0 localhost:3306 && java -jar /app/invest-service-latest.jar"
+    command: /bin/bash -c "wait-for-it -t 0 localhost:3306 && /app/start /app/invest-service-latest.jar"
+    mem_limit: 512M
     network_mode: "host"
     ports:
       - 10012:10012
     environment:
+      RESERVED_MEGABYTES: 64
       SPRING_PROFILES_ACTIVE: dev
 
   trade-service:
     build: trade-service
-    command: /bin/bash -c "wait-for-it -t 0 localhost:3306 && java -jar /app/trade-service-latest.jar"
+    command: /bin/bash -c "wait-for-it -t 0 localhost:3306 && /app/start /app/trade-service-latest.jar"
+    mem_limit: 512M
     network_mode: "host"
     ports:
       - 10013:10013
     environment:
+      RESERVED_MEGABYTES: 64
       SPRING_PROFILES_ACTIVE: dev

--- a/createdb.sh
+++ b/createdb.sh
@@ -1,0 +1,1 @@
+mysql -h127.0.0.1 -uroot -ppassword < createdb.sql

--- a/createdb.sql
+++ b/createdb.sql
@@ -1,0 +1,11 @@
+CREATE DATABASE IF NOT EXISTS funddb;
+GRANT ALL ON funddb.* TO 'mariadb'@'%';
+
+CREATE DATABASE IF NOT EXISTS investdb;
+GRANT ALL ON investdb.* TO 'mariadb'@'%';
+
+CREATE DATABASE IF NOT EXISTS inventorydb;
+GRANT ALL ON inventorydb.* TO 'mariadb'@'%';
+
+CREATE DATABASE IF NOT EXISTS tradedb;
+GRANT ALL ON tradedb.* TO 'mariadb'@'%';

--- a/discovery-service/Dockerfile
+++ b/discovery-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:8-jre
 
 RUN mkdir /app
 WORKDIR /app
@@ -6,4 +6,4 @@ WORKDIR /app
 ADD build/libs/discovery-service-0.0.1-SNAPSHOT.jar /app
 RUN ln -sf discovery-service-0.0.1-SNAPSHOT.jar discovery-service-latest.jar
 
-CMD java -jar /app/discovery-service-latest.jar
+CMD java -Xmx128m -jar /app/discovery-service-latest.jar

--- a/discovery-service/Dockerfile
+++ b/discovery-service/Dockerfile
@@ -6,4 +6,7 @@ WORKDIR /app
 ADD build/libs/discovery-service-0.0.1-SNAPSHOT.jar /app
 RUN ln -sf discovery-service-0.0.1-SNAPSHOT.jar discovery-service-latest.jar
 
-CMD java -Xmx128m -jar /app/discovery-service-latest.jar
+ADD start.sh /app/start
+RUN chmod +x /app/start
+
+CMD /app/start /app/discovery-service-latest.jar

--- a/discovery-service/start.sh
+++ b/discovery-service/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+limit_in_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+
+# If not default limit_in_bytes in cgroup
+if [ "$limit_in_bytes" -ne "9223372036854771712" ]
+then
+    limit_in_megabytes=$(expr $limit_in_bytes \/ 1048576)
+    heap_size=$(expr $limit_in_megabytes - $RESERVED_MEGABYTES)
+    export JAVA_OPTS="-Xmx${heap_size}m $JAVA_OPTS"
+fi
+
+echo RESERVED_MEGABYTES=$RESERVED_MEGABYTES JAVA_OPTS=$JAVA_OPTS
+java $JAVA_OPTS -jar $1

--- a/discovery-service/start.sh
+++ b/discovery-service/start.sh
@@ -4,6 +4,9 @@ limit_in_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 # If not default limit_in_bytes in cgroup
 if [ "$limit_in_bytes" -ne "9223372036854771712" ]
 then
+    if [ -z $RESERVED_MEGABYTES ]; then
+        RESERVED_MEGABYTES=64
+    fi
     limit_in_megabytes=$(expr $limit_in_bytes \/ 1048576)
     heap_size=$(expr $limit_in_megabytes - $RESERVED_MEGABYTES)
     export JAVA_OPTS="-Xmx${heap_size}m $JAVA_OPTS"

--- a/edge-service/Dockerfile
+++ b/edge-service/Dockerfile
@@ -9,4 +9,7 @@ RUN chmod +x /usr/local/bin/wait-for-it
 ADD ./build/libs/edge-service-0.0.1-SNAPSHOT.jar /app
 RUN ln -sf edge-service-0.0.1-SNAPSHOT.jar edge-service-latest.jar
 
-CMD java -Xmx128m -jar /app/edge-service-latest.jar
+ADD start.sh /app/start
+RUN chmod +x /app/start
+
+CMD /app/start /app/edge-service-latest.jar

--- a/edge-service/Dockerfile
+++ b/edge-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:8-jre
 
 RUN mkdir /app
 WORKDIR /app
@@ -9,4 +9,4 @@ RUN chmod +x /usr/local/bin/wait-for-it
 ADD ./build/libs/edge-service-0.0.1-SNAPSHOT.jar /app
 RUN ln -sf edge-service-0.0.1-SNAPSHOT.jar edge-service-latest.jar
 
-CMD java -jar /app/edge-service-latest.jar
+CMD java -Xmx128m -jar /app/edge-service-latest.jar

--- a/edge-service/build.gradle
+++ b/edge-service/build.gradle
@@ -29,8 +29,13 @@ repositories {
     maven { url "https://repo.spring.io/milestone" }
 }
 
+configurations {
+    compile.exclude module: "spring-boot-starter-tomcat"
+}
+
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-web")
+	compile('org.springframework.boot:spring-boot-starter-undertow')
     compile('org.springframework.cloud:spring-cloud-starter-zuul')
     compile('org.springframework.cloud:spring-cloud-starter-eureka')
 

--- a/edge-service/start.sh
+++ b/edge-service/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+limit_in_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+
+# If not default limit_in_bytes in cgroup
+if [ "$limit_in_bytes" -ne "9223372036854771712" ]
+then
+    limit_in_megabytes=$(expr $limit_in_bytes \/ 1048576)
+    heap_size=$(expr $limit_in_megabytes - $RESERVED_MEGABYTES)
+    export JAVA_OPTS="-Xmx${heap_size}m $JAVA_OPTS"
+fi
+
+echo RESERVED_MEGABYTES=$RESERVED_MEGABYTES JAVA_OPTS=$JAVA_OPTS
+java $JAVA_OPTS -jar $1

--- a/edge-service/start.sh
+++ b/edge-service/start.sh
@@ -4,6 +4,9 @@ limit_in_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 # If not default limit_in_bytes in cgroup
 if [ "$limit_in_bytes" -ne "9223372036854771712" ]
 then
+    if [ -z $RESERVED_MEGABYTES ]; then
+        RESERVED_MEGABYTES=64
+    fi
     limit_in_megabytes=$(expr $limit_in_bytes \/ 1048576)
     heap_size=$(expr $limit_in_megabytes - $RESERVED_MEGABYTES)
     export JAVA_OPTS="-Xmx${heap_size}m $JAVA_OPTS"

--- a/fund-service/Dockerfile
+++ b/fund-service/Dockerfile
@@ -8,4 +8,7 @@ RUN chmod +x /usr/local/bin/wait-for-it
 
 ADD build/libs/fund-service-0.0.1-SNAPSHOT.jar /app
 RUN ln -sf fund-service-0.0.1-SNAPSHOT.jar fund-service-latest.jar
-CMD java -Xmx128m -jar /app/fund-service-latest.jar
+
+ADD start.sh /app/start
+RUN chmod +x /app/start
+

--- a/fund-service/Dockerfile
+++ b/fund-service/Dockerfile
@@ -12,3 +12,4 @@ RUN ln -sf fund-service-0.0.1-SNAPSHOT.jar fund-service-latest.jar
 ADD start.sh /app/start
 RUN chmod +x /app/start
 
+CMD /app/start /app/fund-service-latest.jar

--- a/fund-service/Dockerfile
+++ b/fund-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:8-jre
 
 RUN mkdir /app
 WORKDIR /app
@@ -8,4 +8,4 @@ RUN chmod +x /usr/local/bin/wait-for-it
 
 ADD build/libs/fund-service-0.0.1-SNAPSHOT.jar /app
 RUN ln -sf fund-service-0.0.1-SNAPSHOT.jar fund-service-latest.jar
-CMD java -jar /app/fund-service-latest.jar
+CMD java -Xmx128m -jar /app/fund-service-latest.jar

--- a/fund-service/build.gradle
+++ b/fund-service/build.gradle
@@ -39,9 +39,14 @@ repositories {
 }
 
 
+configurations {
+    compile.exclude module: "spring-boot-starter-tomcat"
+}
+
 dependencies {
     compile('org.springframework.boot:spring-boot-starter-hateoas')
     compile('org.springframework.boot:spring-boot-starter-web')
+	compile('org.springframework.boot:spring-boot-starter-undertow')
     compile('org.springframework.cloud:spring-cloud-starter-eureka')
     compile("org.springframework.cloud:spring-cloud-starter-hystrix")
 

--- a/fund-service/start.sh
+++ b/fund-service/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+limit_in_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+
+# If not default limit_in_bytes in cgroup
+if [ "$limit_in_bytes" -ne "9223372036854771712" ]
+then
+    limit_in_megabytes=$(expr $limit_in_bytes \/ 1048576)
+    heap_size=$(expr $limit_in_megabytes - $RESERVED_MEGABYTES)
+    export JAVA_OPTS="-Xmx${heap_size}m $JAVA_OPTS"
+fi
+
+echo RESERVED_MEGABYTES=$RESERVED_MEGABYTES JAVA_OPTS=$JAVA_OPTS
+java $JAVA_OPTS -jar $1

--- a/fund-service/start.sh
+++ b/fund-service/start.sh
@@ -4,6 +4,9 @@ limit_in_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 # If not default limit_in_bytes in cgroup
 if [ "$limit_in_bytes" -ne "9223372036854771712" ]
 then
+    if [ -z $RESERVED_MEGABYTES ]; then
+        RESERVED_MEGABYTES=64
+    fi
     limit_in_megabytes=$(expr $limit_in_bytes \/ 1048576)
     heap_size=$(expr $limit_in_megabytes - $RESERVED_MEGABYTES)
     export JAVA_OPTS="-Xmx${heap_size}m $JAVA_OPTS"

--- a/infrastructure.yml
+++ b/infrastructure.yml
@@ -3,47 +3,46 @@ services:
 
   funddb:
     image: mariadb
-    container_name: funddb
+    container_name: database
     ports:
       - 3306:3306
     environment:
       MYSQL_USER: mariadb
       MYSQL_PASSWORD: mariadb
       MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: funddb
 
-  inventorydb:
-    image: mariadb
-    container_name: inventorydb
-    ports:
-      - 3307:3306
-    environment:
-      MYSQL_USER: mariadb
-      MYSQL_PASSWORD: mariadb
-      MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: inventorydb
-
-  investdb:
-    image: mariadb
-    container_name: investdb
-    ports:
-      - 3308:3306
-    environment:
-      MYSQL_USER: mariadb
-      MYSQL_PASSWORD: mariadb
-      MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: investdb
-
-  tradedb:
-    image: mariadb
-    container_name: tradedb
-    ports:
-      - 3309:3306
-    environment:
-      MYSQL_USER: mariadb
-      MYSQL_PASSWORD: mariadb
-      MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: tradedb
+#  inventorydb:
+#    image: mariadb
+#    container_name: inventorydb
+#    ports:
+#      - 3307:3306
+#    environment:
+#      MYSQL_USER: mariadb
+#      MYSQL_PASSWORD: mariadb
+#      MYSQL_ROOT_PASSWORD: password
+#      MYSQL_DATABASE: inventorydb
+#
+#  investdb:
+#    image: mariadb
+#    container_name: investdb
+#    ports:
+#      - 3308:3306
+#    environment:
+#      MYSQL_USER: mariadb
+#      MYSQL_PASSWORD: mariadb
+#      MYSQL_ROOT_PASSWORD: password
+#      MYSQL_DATABASE: investdb
+#
+#  tradedb:
+#    image: mariadb
+#    container_name: tradedb
+#    ports:
+#      - 3309:3306
+#    environment:
+#      MYSQL_USER: mariadb
+#      MYSQL_PASSWORD: mariadb
+#      MYSQL_ROOT_PASSWORD: password
+#      MYSQL_DATABASE: tradedb
 
   kafka:
     image: spotify/kafka

--- a/infrastructure.yml
+++ b/infrastructure.yml
@@ -28,5 +28,4 @@ services:
     ports:
       - 10100:10100
     environment:
-      RESERVED_MEGABYTES: 64
       SPRING_PROFILES_ACTIVE: dev

--- a/infrastructure.yml
+++ b/infrastructure.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
 
-  funddb:
+  database:
     image: mariadb
     container_name: database
     ports:
@@ -10,39 +10,6 @@ services:
       MYSQL_USER: mariadb
       MYSQL_PASSWORD: mariadb
       MYSQL_ROOT_PASSWORD: password
-
-#  inventorydb:
-#    image: mariadb
-#    container_name: inventorydb
-#    ports:
-#      - 3307:3306
-#    environment:
-#      MYSQL_USER: mariadb
-#      MYSQL_PASSWORD: mariadb
-#      MYSQL_ROOT_PASSWORD: password
-#      MYSQL_DATABASE: inventorydb
-#
-#  investdb:
-#    image: mariadb
-#    container_name: investdb
-#    ports:
-#      - 3308:3306
-#    environment:
-#      MYSQL_USER: mariadb
-#      MYSQL_PASSWORD: mariadb
-#      MYSQL_ROOT_PASSWORD: password
-#      MYSQL_DATABASE: investdb
-#
-#  tradedb:
-#    image: mariadb
-#    container_name: tradedb
-#    ports:
-#      - 3309:3306
-#    environment:
-#      MYSQL_USER: mariadb
-#      MYSQL_PASSWORD: mariadb
-#      MYSQL_ROOT_PASSWORD: password
-#      MYSQL_DATABASE: tradedb
 
   kafka:
     image: spotify/kafka
@@ -57,7 +24,9 @@ services:
   discovery-service:
     build: discovery-service
     container_name: discovery-service
+    mem_limit: 512M
     ports:
       - 10100:10100
     environment:
+      RESERVED_MEGABYTES: 64
       SPRING_PROFILES_ACTIVE: dev

--- a/inventory-service/Dockerfile
+++ b/inventory-service/Dockerfile
@@ -12,3 +12,4 @@ RUN ln -sf inventory-service-0.0.1-SNAPSHOT.jar inventory-service-latest.jar
 ADD start.sh /app/start
 RUN chmod +x /app/start
 
+CMD /app/start invetory-service-latest.jar

--- a/inventory-service/Dockerfile
+++ b/inventory-service/Dockerfile
@@ -8,4 +8,7 @@ RUN chmod +x /usr/local/bin/wait-for-it
 
 ADD build/libs/inventory-service-0.0.1-SNAPSHOT.jar /app
 RUN ln -sf inventory-service-0.0.1-SNAPSHOT.jar inventory-service-latest.jar
-CMD java -Xmx128m -jar /app/inventory-service-latest.jar
+
+ADD start.sh /app/start
+RUN chmod +x /app/start
+

--- a/inventory-service/Dockerfile
+++ b/inventory-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:8-jre
 
 RUN mkdir /app
 WORKDIR /app
@@ -8,4 +8,4 @@ RUN chmod +x /usr/local/bin/wait-for-it
 
 ADD build/libs/inventory-service-0.0.1-SNAPSHOT.jar /app
 RUN ln -sf inventory-service-0.0.1-SNAPSHOT.jar inventory-service-latest.jar
-CMD java -jar /app/inventory-service-latest.jar
+CMD java -Xmx128m -jar /app/inventory-service-latest.jar

--- a/inventory-service/build.gradle
+++ b/inventory-service/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 flyway {
-	url = 'jdbc:mysql://localhost:3307/inventorydb'
+	url = 'jdbc:mysql://localhost:3306/inventorydb'
 	user = 'mariadb'
 	password = "mariadb"
 }
@@ -39,13 +39,18 @@ repositories {
 }
 
 //to avoid compiling error about conflicts
-configurations.all {
+configurations.all{
 	exclude group: "org.slf4j", module: "slf4j-log4j12"
+}
+
+configurations {
+    compile.exclude module: "spring-boot-starter-tomcat"
 }
 
 dependencies {
 	compile('org.springframework.boot:spring-boot-starter-hateoas')
 	compile('org.springframework.boot:spring-boot-starter-web')
+	compile('org.springframework.boot:spring-boot-starter-undertow')
 	compile('org.springframework.cloud:spring-cloud-starter-eureka')
 	compile("org.springframework.cloud:spring-cloud-starter-hystrix")
 

--- a/inventory-service/src/main/resources/application.yml
+++ b/inventory-service/src/main/resources/application.yml
@@ -35,7 +35,7 @@ kafka:
 spring:
   profiles: dev
   datasource:
-    url: jdbc:mysql://localhost:3307/inventorydb
+    url: jdbc:mysql://localhost:3306/inventorydb
     username: root
     password: password
 

--- a/inventory-service/start.sh
+++ b/inventory-service/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+limit_in_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+
+# If not default limit_in_bytes in cgroup
+if [ "$limit_in_bytes" -ne "9223372036854771712" ]
+then
+    limit_in_megabytes=$(expr $limit_in_bytes \/ 1048576)
+    heap_size=$(expr $limit_in_megabytes - $RESERVED_MEGABYTES)
+    export JAVA_OPTS="-Xmx${heap_size}m $JAVA_OPTS"
+fi
+
+echo RESERVED_MEGABYTES=$RESERVED_MEGABYTES JAVA_OPTS=$JAVA_OPTS
+java $JAVA_OPTS -jar $1

--- a/inventory-service/start.sh
+++ b/inventory-service/start.sh
@@ -4,6 +4,9 @@ limit_in_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 # If not default limit_in_bytes in cgroup
 if [ "$limit_in_bytes" -ne "9223372036854771712" ]
 then
+    if [ -z $RESERVED_MEGABYTES ]; then
+        RESERVED_MEGABYTES=64
+    fi
     limit_in_megabytes=$(expr $limit_in_bytes \/ 1048576)
     heap_size=$(expr $limit_in_megabytes - $RESERVED_MEGABYTES)
     export JAVA_OPTS="-Xmx${heap_size}m $JAVA_OPTS"

--- a/invest-service/Dockerfile
+++ b/invest-service/Dockerfile
@@ -8,4 +8,7 @@ RUN chmod +x /usr/local/bin/wait-for-it
 
 ADD build/libs/invest-service-0.0.1-SNAPSHOT.jar /app
 RUN ln -sf invest-service-0.0.1-SNAPSHOT.jar invest-service-latest.jar
-CMD java -Xmx128m -jar /app/invest-service-latest.jar
+
+ADD start.sh /app/start
+RUN chmod +x /app/start
+

--- a/invest-service/Dockerfile
+++ b/invest-service/Dockerfile
@@ -12,3 +12,4 @@ RUN ln -sf invest-service-0.0.1-SNAPSHOT.jar invest-service-latest.jar
 ADD start.sh /app/start
 RUN chmod +x /app/start
 
+CMD /app/start /app/invest-service-latest.jar

--- a/invest-service/Dockerfile
+++ b/invest-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:8-jre
 
 RUN mkdir /app
 WORKDIR /app
@@ -8,4 +8,4 @@ RUN chmod +x /usr/local/bin/wait-for-it
 
 ADD build/libs/invest-service-0.0.1-SNAPSHOT.jar /app
 RUN ln -sf invest-service-0.0.1-SNAPSHOT.jar invest-service-latest.jar
-CMD java -jar /app/invest-service-latest.jar
+CMD java -Xmx128m -jar /app/invest-service-latest.jar

--- a/invest-service/build.gradle
+++ b/invest-service/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 flyway {
-	url = 'jdbc:mysql://localhost:3308/investdb'
+	url = 'jdbc:mysql://localhost:3306/investdb'
 	user = 'mariadb'
 	password = "mariadb"
 }
@@ -38,10 +38,14 @@ repositories {
 	maven { url "https://repo.spring.io/milestone" }
 }
 
+configurations {
+    compile.exclude module: "spring-boot-starter-tomcat"
+}
 
 dependencies {
 	compile('org.springframework.boot:spring-boot-starter-hateoas')
 	compile('org.springframework.boot:spring-boot-starter-web')
+	compile('org.springframework.boot:spring-boot-starter-undertow')
 	compile('org.springframework.cloud:spring-cloud-starter-eureka')
 	compile("org.springframework.cloud:spring-cloud-starter-hystrix")
 

--- a/invest-service/src/main/resources/application.yml
+++ b/invest-service/src/main/resources/application.yml
@@ -27,7 +27,7 @@ management:
 spring:
   profiles: dev
   datasource:
-    url: jdbc:mysql://localhost:3308/investdb
+    url: jdbc:mysql://localhost:3306/investdb
     username: root
     password: password
 

--- a/invest-service/start.sh
+++ b/invest-service/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+limit_in_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+
+# If not default limit_in_bytes in cgroup
+if [ "$limit_in_bytes" -ne "9223372036854771712" ]
+then
+    limit_in_megabytes=$(expr $limit_in_bytes \/ 1048576)
+    heap_size=$(expr $limit_in_megabytes - $RESERVED_MEGABYTES)
+    export JAVA_OPTS="-Xmx${heap_size}m $JAVA_OPTS"
+fi
+
+echo RESERVED_MEGABYTES=$RESERVED_MEGABYTES JAVA_OPTS=$JAVA_OPTS
+java $JAVA_OPTS -jar $1

--- a/invest-service/start.sh
+++ b/invest-service/start.sh
@@ -4,6 +4,9 @@ limit_in_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 # If not default limit_in_bytes in cgroup
 if [ "$limit_in_bytes" -ne "9223372036854771712" ]
 then
+    if [ -z $RESERVED_MEGABYTES ]; then
+        RESERVED_MEGABYTES=64
+    fi
     limit_in_megabytes=$(expr $limit_in_bytes \/ 1048576)
     heap_size=$(expr $limit_in_megabytes - $RESERVED_MEGABYTES)
     export JAVA_OPTS="-Xmx${heap_size}m $JAVA_OPTS"

--- a/trade-service/Dockerfile
+++ b/trade-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:8-jre
 
 RUN mkdir /app
 WORKDIR /app
@@ -8,4 +8,4 @@ RUN chmod +x /usr/local/bin/wait-for-it
 
 ADD build/libs/trade-service-0.0.1-SNAPSHOT.jar /app
 RUN ln -sf trade-service-0.0.1-SNAPSHOT.jar trade-service-latest.jar
-CMD java -jar /app/trade-service-latest.jar
+CMD java -Xmx128m -jar /app/trade-service-latest.jar

--- a/trade-service/Dockerfile
+++ b/trade-service/Dockerfile
@@ -8,4 +8,7 @@ RUN chmod +x /usr/local/bin/wait-for-it
 
 ADD build/libs/trade-service-0.0.1-SNAPSHOT.jar /app
 RUN ln -sf trade-service-0.0.1-SNAPSHOT.jar trade-service-latest.jar
-CMD java -Xmx128m -jar /app/trade-service-latest.jar
+
+ADD start.sh /app/start
+RUN chmod +x /app/start
+

--- a/trade-service/Dockerfile
+++ b/trade-service/Dockerfile
@@ -12,3 +12,4 @@ RUN ln -sf trade-service-0.0.1-SNAPSHOT.jar trade-service-latest.jar
 ADD start.sh /app/start
 RUN chmod +x /app/start
 
+CMD /app/start /app/trade-service-latest.jar

--- a/trade-service/build.gradle
+++ b/trade-service/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 flyway {
-	url = 'jdbc:mysql://localhost:3309/tradedb'
+	url = 'jdbc:mysql://localhost:3306/tradedb'
 	user = 'mariadb'
 	password = "mariadb"
 }
@@ -38,10 +38,14 @@ repositories {
 	maven { url "https://repo.spring.io/milestone" }
 }
 
+configurations {
+    compile.exclude module: "spring-boot-starter-tomcat"
+}
 
 dependencies {
 	compile('org.springframework.boot:spring-boot-starter-hateoas')
-	compile('org.springframework.boot:spring-boot-starter-web')
+    compile('org.springframework.boot:spring-boot-starter-web')
+    compile('org.springframework.boot:spring-boot-starter-undertow')
 	compile('org.springframework.cloud:spring-cloud-starter-eureka')
 	compile("org.springframework.cloud:spring-cloud-starter-hystrix")
 

--- a/trade-service/src/main/resources/application.yml
+++ b/trade-service/src/main/resources/application.yml
@@ -27,7 +27,7 @@ management:
 spring:
   profiles: dev
   datasource:
-    url: jdbc:mysql://localhost:3309/tradedb
+    url: jdbc:mysql://localhost:3306/tradedb
     username: mariadb
     password: mariadb
 

--- a/trade-service/start.sh
+++ b/trade-service/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+limit_in_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+
+# If not default limit_in_bytes in cgroup
+if [ "$limit_in_bytes" -ne "9223372036854771712" ]
+then
+    limit_in_megabytes=$(expr $limit_in_bytes \/ 1048576)
+    heap_size=$(expr $limit_in_megabytes - $RESERVED_MEGABYTES)
+    export JAVA_OPTS="-Xmx${heap_size}m $JAVA_OPTS"
+fi
+
+echo RESERVED_MEGABYTES=$RESERVED_MEGABYTES JAVA_OPTS=$JAVA_OPTS
+java $JAVA_OPTS -jar $1

--- a/trade-service/start.sh
+++ b/trade-service/start.sh
@@ -4,6 +4,9 @@ limit_in_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 # If not default limit_in_bytes in cgroup
 if [ "$limit_in_bytes" -ne "9223372036854771712" ]
 then
+    if [ -z $RESERVED_MEGABYTES ]; then
+        RESERVED_MEGABYTES=64
+    fi
     limit_in_megabytes=$(expr $limit_in_bytes \/ 1048576)
     heap_size=$(expr $limit_in_megabytes - $RESERVED_MEGABYTES)
     export JAVA_OPTS="-Xmx${heap_size}m $JAVA_OPTS"


### PR DESCRIPTION
主要改动：

* 合并数据库，由4个数据库实例减少至1个。在一个实例内建立多个数据库，增加数据库创建脚本（需要mysql命令行支持）
* docker基础包由 openjdk:8 改成 openjdk:8-jre
* 修改Dockerfile中的java应用启动命令，增加限制内存的参数
* 将内嵌web server由tomcat改成undertow