### PR TITLE
增加持续部署的功能

### DIFF
--- a/application-cd.yml
+++ b/application-cd.yml
@@ -1,0 +1,62 @@
+version: '2'
+services:
+
+
+  fund-service:
+    image: docker-registry:5000/fund-service
+    command: /bin/bash -c "wait-for-it -t 0 localhost:3306 && /app/start /app/fund-service-latest.jar"
+    mem_limit: 512M
+    network_mode: "host"
+    ports:
+      - 10010:10010
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+
+  inventory-service:
+    image: docker-registry:5000/inventory-service
+    command: /bin/bash -c "wait-for-it -t 0 localhost:3306 && /app/start /app/inventory-service-latest.jar"
+    mem_limit: 512M
+    network_mode: "host"
+    ports:
+      - 10011:10011
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+ 
+  invest-service:
+    image: docker-registry:5000/invest-service
+    command: /bin/bash -c "wait-for-it -t 0 localhost:3306 && /app/start /app/invest-service-latest.jar"
+    mem_limit: 512M
+    network_mode: "host"
+    ports:
+      - 10012:10012
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+
+  trade-service:
+    image: docker-registry:5000/trade-service
+    command: /bin/bash -c "wait-for-it -t 0 localhost:3306 && /app/start /app/trade-service-latest.jar"
+    mem_limit: 512M
+    network_mode: "host"
+    ports:
+      - 10013:10013
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+
+  web-gateway:
+    image: docker-registry:5000/web-gateway
+    mem_limit: 512M
+    network_mode: "host"
+    ports:
+      - 8088:8088
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+
+  sequence-service:
+    image: docker-registry:5000/sequence-service
+    container_name: sequence-service
+    mem_limit: 512M
+    network_mode: "host"
+    ports:
+      - 10200:10200
+    environment:
+      SPRING_PROFILES_ACTIVE: dev

--- a/continuous-deploy.sh
+++ b/continuous-deploy.sh
@@ -18,11 +18,11 @@ cd ${COMMIT_WORKSPACE}
 docker-compose -f infrastructure-cd.yml down
 docker-compose -f infrastructure-cd.yml up -d
 
-# wait for infrastructures startup complete. 
-# need to be replaced by wait-for-it
-sleep 10
-
 HOST_IP=$(ip route|awk '/default/ { print $3 }')
+
+# wait for infrastructures startup complete. 
+bash ./wait-for-it.sh -t 0 ${HOST_IP}:3306
+
 ./createdb.sh ${HOST_IP}
 ./migratedb.sh ${HOST_IP}
 

--- a/continuous-deploy.sh
+++ b/continuous-deploy.sh
@@ -1,18 +1,10 @@
 CURR_TAG=${COMMIT_BUILD_TYPE}${COMMIT_BUILD_NUMBER}
 
-echo "BEFORE:"
-docker images
-
 for name in discovery-service fund-service trade-service invest-service inventory-service web-gateway sequence-service
 do
     docker rmi docker-registry:5000/${name}:latest
     docker tag docker-registry:5000/${name}:${CURR_TAG} docker-registry:5000/${name}:latest
 done
-
-echo "AFTER:"
-docker images
-
-echo "cd ${COMMIT_WORKSPACE}"
 
 cd ${COMMIT_WORKSPACE}
 docker-compose -f infrastructure-cd.yml down
@@ -22,7 +14,7 @@ HOST_IP=$(ip route|awk '/default/ { print $3 }')
 
 # wait for infrastructures startup complete. 
 bash ./wait-for-it.sh -t 0 ${HOST_IP}:3306
-sleep 20s
+sleep 30s
 
 ./createdb.sh ${HOST_IP}
 ./migratedb.sh ${HOST_IP}

--- a/continuous-deploy.sh
+++ b/continuous-deploy.sh
@@ -3,7 +3,7 @@ CURR_TAG=${COMMIT_BUILD_TYPE}${COMMIT_BUILD_NUMBER}
 echo "BEFORE:"
 docker images
 
-for name in "discovery-service fund-service trade-service invest-service inventory-service web-gateway sequence-service"
+for name in discovery-service fund-service trade-service invest-service inventory-service web-gateway sequence-service
 do
     echo "docker tag docker-registry:5000/${name}:${CURR_TAG} docker-registry:5000/${name}:latest"
     docker tag docker-registry:5000/${name}:${CURR_TAG} docker-registry:5000/${name}:latest

--- a/continuous-deploy.sh
+++ b/continuous-deploy.sh
@@ -22,6 +22,7 @@ HOST_IP=$(ip route|awk '/default/ { print $3 }')
 
 # wait for infrastructures startup complete. 
 bash ./wait-for-it.sh -t 0 ${HOST_IP}:3306
+sleep 10
 
 ./createdb.sh ${HOST_IP}
 ./migratedb.sh ${HOST_IP}

--- a/continuous-deploy.sh
+++ b/continuous-deploy.sh
@@ -2,7 +2,7 @@ CURR_TAG=${COMMIT_BUILD_TYPE}${COMMIT_BUILD_NUMBER}
 
 for name in "discovery-service fund-service trade-service invest-service inventory-service web-gateway sequence-service"
 do
-    docker tag docker-registry:5000/${name}:${CURR_TAG} docker-registry:5000:latest
+    docker tag docker-registry:5000/${name}:${CURR_TAG} docker-registry:5000/${name}:latest
 done
 
 cd ${COMMIT_WORKSPACE}

--- a/continuous-deploy.sh
+++ b/continuous-deploy.sh
@@ -8,7 +8,7 @@ done
 
 cd ${COMMIT_WORKSPACE}
 docker-compose -f infrastructure-cd.yml down
-docker-compose -f infrastructure-cd.yml up --build -d
+docker-compose -f infrastructure-cd.yml up -d
 
 HOST_IP=$(ip route|awk '/default/ { print $3 }')
 

--- a/continuous-deploy.sh
+++ b/continuous-deploy.sh
@@ -5,7 +5,7 @@ docker images
 
 for name in discovery-service fund-service trade-service invest-service inventory-service web-gateway sequence-service
 do
-    echo "docker tag docker-registry:5000/${name}:${CURR_TAG} docker-registry:5000/${name}:latest"
+    docker rmi docker-registry:5000/${name}:latest
     docker tag docker-registry:5000/${name}:${CURR_TAG} docker-registry:5000/${name}:latest
 done
 

--- a/continuous-deploy.sh
+++ b/continuous-deploy.sh
@@ -15,10 +15,16 @@ docker images
 echo "cd ${COMMIT_WORKSPACE}"
 
 cd ${COMMIT_WORKSPACE}
+docker-compose -f infrastructure-cd.yml down
 docker-compose -f infrastructure-cd.yml up -d
+
+# wait for infrastructures startup complete. 
+# need to be replaced by wait-for-it
 sleep 10
 
 HOST_IP=$(ip route|awk '/default/ { print $3 }')
 ./createdb.sh ${HOST_IP}
 ./migratedb.sh ${HOST_IP}
+
+docker-compose -f application-cd.yml down
 docker-compose -f application-cd.yml up -d

--- a/continuous-deploy.sh
+++ b/continuous-deploy.sh
@@ -22,6 +22,7 @@ HOST_IP=$(ip route|awk '/default/ { print $3 }')
 
 # wait for infrastructures startup complete. 
 bash ./wait-for-it.sh -t 0 ${HOST_IP}:3306
+sleep 60s
 
 ./createdb.sh ${HOST_IP}
 ./migratedb.sh ${HOST_IP}

--- a/continuous-deploy.sh
+++ b/continuous-deploy.sh
@@ -1,0 +1,13 @@
+CURR_TAG=${COMMIT_BUILD_TYPE}${COMMIT_BUILD_NUMBER}
+
+for name in "discovery-service fund-service trade-service invest-service inventory-service web-gateway sequence-service"
+do
+    docker tag docker-registry:5000/${name}:${CURR_TAG} docker-registry:5000:latest
+done
+
+cd ${COMMIT_WORKSPACE}
+docker-compose -f infrastructure-cd.yml up -d
+sleep 10
+./createdb.sh
+./migratedb.sh
+docker-compose -f application-cd.yml up -d

--- a/continuous-deploy.sh
+++ b/continuous-deploy.sh
@@ -1,13 +1,24 @@
 CURR_TAG=${COMMIT_BUILD_TYPE}${COMMIT_BUILD_NUMBER}
 
+echo "BEFORE:"
+docker images
+
 for name in "discovery-service fund-service trade-service invest-service inventory-service web-gateway sequence-service"
 do
+    echo "docker tag docker-registry:5000/${name}:${CURR_TAG} docker-registry:5000/${name}:latest"
     docker tag docker-registry:5000/${name}:${CURR_TAG} docker-registry:5000/${name}:latest
 done
+
+echo "AFTER:"
+docker images
+
+echo "cd ${COMMIT_WORKSPACE}"
 
 cd ${COMMIT_WORKSPACE}
 docker-compose -f infrastructure-cd.yml up -d
 sleep 10
-./createdb.sh
-./migratedb.sh
+
+HOST_IP=$(ip route|awk '/default/ { print $3 }')
+./createdb.sh ${HOST_IP}
+./migratedb.sh ${HOST_IP}
 docker-compose -f application-cd.yml up -d

--- a/continuous-deploy.sh
+++ b/continuous-deploy.sh
@@ -16,13 +16,12 @@ echo "cd ${COMMIT_WORKSPACE}"
 
 cd ${COMMIT_WORKSPACE}
 docker-compose -f infrastructure-cd.yml down
-docker-compose -f infrastructure-cd.yml up -d
+docker-compose -f infrastructure-cd.yml up --build -d
 
 HOST_IP=$(ip route|awk '/default/ { print $3 }')
 
 # wait for infrastructures startup complete. 
 bash ./wait-for-it.sh -t 0 ${HOST_IP}:3306
-sleep 10
 
 ./createdb.sh ${HOST_IP}
 ./migratedb.sh ${HOST_IP}

--- a/continuous-deploy.sh
+++ b/continuous-deploy.sh
@@ -22,7 +22,7 @@ HOST_IP=$(ip route|awk '/default/ { print $3 }')
 
 # wait for infrastructures startup complete. 
 bash ./wait-for-it.sh -t 0 ${HOST_IP}:3306
-sleep 10s
+sleep 20s
 
 ./createdb.sh ${HOST_IP}
 ./migratedb.sh ${HOST_IP}

--- a/continuous-deploy.sh
+++ b/continuous-deploy.sh
@@ -22,7 +22,7 @@ HOST_IP=$(ip route|awk '/default/ { print $3 }')
 
 # wait for infrastructures startup complete. 
 bash ./wait-for-it.sh -t 0 ${HOST_IP}:3306
-sleep 60s
+sleep 10s
 
 ./createdb.sh ${HOST_IP}
 ./migratedb.sh ${HOST_IP}

--- a/createdb.sh
+++ b/createdb.sh
@@ -4,4 +4,5 @@ if [ ! $MYSQL_IP_ADDR ]; then
 fi
 
 echo "MYSQL_IP_ADDR=${MYSQL_IP_ADDR}"
+echo "mysql -h${MYSQL_IP_ADDR} -uroot -ppassword < createdb.sql"
 mysql -h${MYSQL_IP_ADDR} -uroot -ppassword < createdb.sql

--- a/createdb.sh
+++ b/createdb.sh
@@ -5,5 +5,5 @@ fi
 
 echo "MYSQL_IP_ADDR=${MYSQL_IP_ADDR}"
 echo "mysql -h${MYSQL_IP_ADDR} -uroot -ppassword < createdb.sql"
-#mysql -h${MYSQL_IP_ADDR} -uroot -ppassword < createdb.sql
-mysql -h${MYSQL_IP_ADDR} -uroot -ppassword -e "show databases;"
+mysql -h${MYSQL_IP_ADDR} -uroot -ppassword < createdb.sql
+#mysql -h${MYSQL_IP_ADDR} -uroot -ppassword -e "show databases;"

--- a/createdb.sh
+++ b/createdb.sh
@@ -5,4 +5,5 @@ fi
 
 echo "MYSQL_IP_ADDR=${MYSQL_IP_ADDR}"
 echo "mysql -h${MYSQL_IP_ADDR} -uroot -ppassword < createdb.sql"
-mysql -h${MYSQL_IP_ADDR} -uroot -ppassword < createdb.sql
+#mysql -h${MYSQL_IP_ADDR} -uroot -ppassword < createdb.sql
+mysql -h${MYSQL_IP_ADDR} -uroot -ppassword -e "show databases;"

--- a/createdb.sh
+++ b/createdb.sh
@@ -1,1 +1,7 @@
-mysql -h127.0.0.1 -uroot -ppassword < createdb.sql
+MYSQL_IP_ADDR=$1
+if [ ! $MYSQL_IP_ADDR ]; then
+    MYSQL_IP_ADDR="127.0.0.1"
+fi
+
+echo "MYSQL_IP_ADDR=${MYSQL_IP_ADDR}"
+mysql -h${MYSQL_IP_ADDR} -uroot -ppassword < createdb.sql

--- a/fund-service/build.gradle
+++ b/fund-service/build.gradle
@@ -17,11 +17,11 @@ plugins {
 
 flyway {
     def env = System.getenv()
-    def mysql_ip_addr = env.MYSQL_IP_ADDR?"127.0.0.1":env.MYSQL_IP_ADDR
+    def mysql_ip_addr = env.MYSQL_IP_ADDR?env.MYSQL_IP_ADDR:"127.0.0.1"
 
     url = "jdbc:mysql://$mysql_ip_addr:3306/funddb"
     print "mysql url: $url"    
-    
+
     user = 'mariadb'
     password = "mariadb"
 }

--- a/fund-service/build.gradle
+++ b/fund-service/build.gradle
@@ -16,7 +16,12 @@ plugins {
 }
 
 flyway {
-    url = 'jdbc:mysql://localhost:3306/funddb'
+    def env = System.getenv()
+    def mysql_ip_addr = env.MYSQL_IP_ADDR?"127.0.0.1":env.MYSQL_IP_ADDR
+
+    url = "jdbc:mysql://$mysql_ip_addr:3306/funddb"
+    print "mysql url: $url"    
+    
     user = 'mariadb'
     password = "mariadb"
 }

--- a/fund-service/build.gradle
+++ b/fund-service/build.gradle
@@ -20,7 +20,7 @@ flyway {
     def mysql_ip_addr = env.MYSQL_IP_ADDR?env.MYSQL_IP_ADDR:"127.0.0.1"
 
     url = "jdbc:mysql://$mysql_ip_addr:3306/funddb"
-    print "mysql url: $url"    
+    println "mysql url: $url"    
 
     user = 'mariadb'
     password = "mariadb"

--- a/infrastructure-cd.yml
+++ b/infrastructure-cd.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
 
   database:
-    image: mariadb
+    build: mariadb-docker
     container_name: database
     ports:
       - 3306:3306

--- a/infrastructure-cd.yml
+++ b/infrastructure-cd.yml
@@ -22,7 +22,7 @@ services:
       - ADVERTISED_PORT=9092
 
   discovery-service:
-    build: docker-registry:5000/discovery-service
+    image: docker-registry:5000/discovery-service
     container_name: discovery-service
     mem_limit: 512M
     ports:

--- a/infrastructure-cd.yml
+++ b/infrastructure-cd.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
 
   database:
-    build: mariadb-docker
+    image: mariadb
     container_name: database
     ports:
       - 3306:3306

--- a/infrastructure-cd.yml
+++ b/infrastructure-cd.yml
@@ -1,0 +1,39 @@
+version: '2'
+services:
+
+  database:
+    image: mariadb
+    container_name: database
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_USER: mariadb
+      MYSQL_PASSWORD: mariadb
+      MYSQL_ROOT_PASSWORD: password
+
+  kafka:
+    image: spotify/kafka
+    container_name: kafka
+    ports:
+      - 9092:9092
+      - 2181:2181
+    environment:
+      - ADVERTISED_HOST=127.0.0.1
+      - ADVERTISED_PORT=9092
+
+  discovery-service:
+    build: docker-registry:5000/discovery-service
+    container_name: discovery-service
+    mem_limit: 512M
+    ports:
+      - 10100:10100
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+
+  redis:
+    image: redis
+    container_name: redis
+    ports:
+      - 6379:6379
+
+  

--- a/inventory-service/build.gradle
+++ b/inventory-service/build.gradle
@@ -21,7 +21,7 @@ flyway {
     def mysql_ip_addr = env.MYSQL_IP_ADDR?env.MYSQL_IP_ADDR:"127.0.0.1"
 
     url = "jdbc:mysql://$mysql_ip_addr:3306/inventorydb"
-    print "mysql url: $url"    
+    println "mysql url: $url"    
     
 	user = 'mariadb'
 	password = "mariadb"

--- a/inventory-service/build.gradle
+++ b/inventory-service/build.gradle
@@ -17,7 +17,12 @@ plugins {
 }
 
 flyway {
-	url = 'jdbc:mysql://localhost:3306/inventorydb'
+    def env = System.getenv()
+    def mysql_ip_addr = env.MYSQL_IP_ADDR?"127.0.0.1":env.MYSQL_IP_ADDR
+
+    url = "jdbc:mysql://$mysql_ip_addr:3306/funddb"
+    print "mysql url: $url"    
+    
 	user = 'mariadb'
 	password = "mariadb"
 }

--- a/inventory-service/build.gradle
+++ b/inventory-service/build.gradle
@@ -20,7 +20,7 @@ flyway {
     def env = System.getenv()
     def mysql_ip_addr = env.MYSQL_IP_ADDR?"127.0.0.1":env.MYSQL_IP_ADDR
 
-    url = "jdbc:mysql://$mysql_ip_addr:3306/funddb"
+    url = "jdbc:mysql://$mysql_ip_addr:3306/inventorydb"
     print "mysql url: $url"    
     
 	user = 'mariadb'

--- a/inventory-service/build.gradle
+++ b/inventory-service/build.gradle
@@ -18,7 +18,7 @@ plugins {
 
 flyway {
     def env = System.getenv()
-    def mysql_ip_addr = env.MYSQL_IP_ADDR?"127.0.0.1":env.MYSQL_IP_ADDR
+    def mysql_ip_addr = env.MYSQL_IP_ADDR?env.MYSQL_IP_ADDR:"127.0.0.1"
 
     url = "jdbc:mysql://$mysql_ip_addr:3306/inventorydb"
     print "mysql url: $url"    

--- a/invest-service/build.gradle
+++ b/invest-service/build.gradle
@@ -17,7 +17,7 @@ plugins {
 
 flyway {
     def env = System.getenv()
-    def mysql_ip_addr = env.MYSQL_IP_ADDR?"127.0.0.1":env.MYSQL_IP_ADDR
+    def mysql_ip_addr = env.MYSQL_IP_ADDR?env.MYSQL_IP_ADDR:"127.0.0.1"
 
     url = "jdbc:mysql://$mysql_ip_addr:3306/investdb"
     print "mysql url: $url"    

--- a/invest-service/build.gradle
+++ b/invest-service/build.gradle
@@ -20,7 +20,7 @@ flyway {
     def mysql_ip_addr = env.MYSQL_IP_ADDR?env.MYSQL_IP_ADDR:"127.0.0.1"
 
     url = "jdbc:mysql://$mysql_ip_addr:3306/investdb"
-    print "mysql url: $url"    
+    println "mysql url: $url"    
     
 	user = 'mariadb'
 	password = "mariadb"

--- a/invest-service/build.gradle
+++ b/invest-service/build.gradle
@@ -16,7 +16,12 @@ plugins {
 }
 
 flyway {
-	url = 'jdbc:mysql://localhost:3306/investdb'
+    def env = System.getenv()
+    def mysql_ip_addr = env.MYSQL_IP_ADDR?"127.0.0.1":env.MYSQL_IP_ADDR
+
+    url = "jdbc:mysql://$mysql_ip_addr:3306/funddb"
+    print "mysql url: $url"    
+    
 	user = 'mariadb'
 	password = "mariadb"
 }

--- a/invest-service/build.gradle
+++ b/invest-service/build.gradle
@@ -19,7 +19,7 @@ flyway {
     def env = System.getenv()
     def mysql_ip_addr = env.MYSQL_IP_ADDR?"127.0.0.1":env.MYSQL_IP_ADDR
 
-    url = "jdbc:mysql://$mysql_ip_addr:3306/funddb"
+    url = "jdbc:mysql://$mysql_ip_addr:3306/investdb"
     print "mysql url: $url"    
     
 	user = 'mariadb'

--- a/mariadb-docker/Dockerfile
+++ b/mariadb-docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM: mariadb
+
+# comment out a few problematic configuration values
+# don't reverse lookup hostnames, they are usually another container
+RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/my.cnf \
+	&& echo 'skip-host-cache\nskip-name-resolve' | awk '{ print } $1 == "[mysqld]" && c == 0 { c = 1; system("cat") }' /etc/mysql/my.cnf > /tmp/my.cnf \
+	&& mv /tmp/my.cnf /etc/mysql/my.cnf

--- a/mariadb-docker/Dockerfile
+++ b/mariadb-docker/Dockerfile
@@ -3,3 +3,4 @@ FROM mariadb
 # comment out a few problematic configuration values
 # don't reverse lookup hostnames, they are usually another container
 RUN sed -Ei 's/^#bind-address=0.0.0.0/bind-address=0.0.0.0/' /etc/mysql/my.cnf 
+RUN echo "mysqld: ALL" >> /etc/hosts.allow

--- a/mariadb-docker/Dockerfile
+++ b/mariadb-docker/Dockerfile
@@ -1,6 +1,0 @@
-FROM mariadb
-
-# comment out a few problematic configuration values
-# don't reverse lookup hostnames, they are usually another container
-RUN sed -Ei 's/^#bind-address=0.0.0.0/bind-address=0.0.0.0/' /etc/mysql/my.cnf 
-RUN echo "mysqld: ALL" >> /etc/hosts.allow

--- a/mariadb-docker/Dockerfile
+++ b/mariadb-docker/Dockerfile
@@ -2,6 +2,4 @@ FROM mariadb
 
 # comment out a few problematic configuration values
 # don't reverse lookup hostnames, they are usually another container
-RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/my.cnf \
-	&& echo 'skip-host-cache\nskip-name-resolve' | awk '{ print } $1 == "[mysqld]" && c == 0 { c = 1; system("cat") }' /etc/mysql/my.cnf > /tmp/my.cnf \
-	&& mv /tmp/my.cnf /etc/mysql/my.cnf
+RUN sed -Ei 's/^#bind-address=0.0.0.0/bind-address=0.0.0.0/' /etc/mysql/my.cnf 

--- a/mariadb-docker/Dockerfile
+++ b/mariadb-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM: mariadb
+FROM mariadb
 
 # comment out a few problematic configuration values
 # don't reverse lookup hostnames, they are usually another container

--- a/migratedb.sh
+++ b/migratedb.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+MYSQL_IP_ADDR=$1
+if [ ! $MYSQL_IP_ADDR ]; then
+    MYSQL_IP_ADDR="127.0.0.1"
+fi
+
 cd fund-service
 ./gradlew flywayMigrate
 cd -

--- a/migratedb.sh
+++ b/migratedb.sh
@@ -5,6 +5,8 @@ if [ ! $MYSQL_IP_ADDR ]; then
     MYSQL_IP_ADDR="127.0.0.1"
 fi
 
+export MYSQL_IP_ADDR
+
 cd fund-service
 ./gradlew flywayMigrate
 cd -

--- a/sequence-service/build.gradle
+++ b/sequence-service/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 	}
 	dependencies {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+        classpath 'se.transmode.gradle:gradle-docker:1.2'
 	}
 }
 
@@ -14,6 +15,7 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
+apply plugin: 'docker'
 
 jar {
 	baseName = 'sequence-service'
@@ -54,6 +56,57 @@ dependencies {
 	compile('org.projectlombok:lombok')
 
 	testCompile('org.springframework.boot:spring-boot-starter-test')
+}
+
+def getVersion() {
+    def env = System.getenv()
+    def buildNumber = env.BUILD_NUMBER?.toInteger()
+    def buildType = env.BUILD_TYPE
+
+    def version = String.format("%s%d", buildType?buildType:"dev", buildNumber?buildNumber:0)
+    return version
+}
+
+task updateVersion << {
+    def env = System.getenv()
+    def workspace = env.WORKSPACE
+
+    if (!workspace?.trim()){
+        workspace = ".."
+    }
+
+    def version = getVersion()
+    println "[updateVersion]version= $version"
+    def app_yml = String.format("%s/%s/src/main/resources/application.yml", workspace, jar.baseName)
+    String contents = new File(app_yml).getText("UTF-8")
+
+    contents = contents.replaceAll('%%VERSION%%', version)
+    new File(app_yml).write(contents, "UTF-8")
+}
+
+docker {
+    registry = "docker-registry:5000"
+}
+
+task copyJar(dependsOn: 'jar') << {
+    copy {
+        from "."
+        into "build/docker"
+        include "wait-for-it.sh"
+        include "start.sh"
+        include "build/libs/${jar.baseName}-${jar.version}.jar"
+    }
+}
+
+task buildDocker(type: Docker) {
+    dependsOn copyJar
+
+    project.group = docker.registry
+    applicationName = jar.baseName
+    tagVersion = getVersion()
+    println "[docker]version= $tagVersion"
+    dockerfile = "Dockerfile"
+    push = true
 }
 
 dependencyManagement {

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,7 @@
+CURR_TAG=${COMMIT_BUILD_TYPE}${COMMIT_BUILD_NUMBER}
+
+for name in discovery-service fund-service trade-service invest-service inventory-service web-gateway sequence-service
+do
+    echo "docker tag docker-registry:5000/${name}:${CURR_TAG} docker-registry:5000/${name}:latest"
+done
+

--- a/trade-service/build.gradle
+++ b/trade-service/build.gradle
@@ -16,7 +16,12 @@ plugins {
 }
 
 flyway {
-	url = 'jdbc:mysql://localhost:3306/tradedb'
+    def env = System.getenv()
+    def mysql_ip_addr = env.MYSQL_IP_ADDR?"127.0.0.1":env.MYSQL_IP_ADDR
+
+    url = "jdbc:mysql://$mysql_ip_addr:3306/funddb"
+    print "mysql url: $url"    
+    
 	user = 'mariadb'
 	password = "mariadb"
 }

--- a/trade-service/build.gradle
+++ b/trade-service/build.gradle
@@ -20,7 +20,7 @@ flyway {
     def mysql_ip_addr = env.MYSQL_IP_ADDR?env.MYSQL_IP_ADDR:"127.0.0.1"
 
     url = "jdbc:mysql://$mysql_ip_addr:3306/tradedb"
-    print "mysql url: $url"    
+    println "mysql url: $url"    
     
 	user = 'mariadb'
 	password = "mariadb"

--- a/trade-service/build.gradle
+++ b/trade-service/build.gradle
@@ -17,7 +17,7 @@ plugins {
 
 flyway {
     def env = System.getenv()
-    def mysql_ip_addr = env.MYSQL_IP_ADDR?"127.0.0.1":env.MYSQL_IP_ADDR
+    def mysql_ip_addr = env.MYSQL_IP_ADDR?env.MYSQL_IP_ADDR:"127.0.0.1"
 
     url = "jdbc:mysql://$mysql_ip_addr:3306/tradedb"
     print "mysql url: $url"    

--- a/trade-service/build.gradle
+++ b/trade-service/build.gradle
@@ -19,7 +19,7 @@ flyway {
     def env = System.getenv()
     def mysql_ip_addr = env.MYSQL_IP_ADDR?"127.0.0.1":env.MYSQL_IP_ADDR
 
-    url = "jdbc:mysql://$mysql_ip_addr:3306/funddb"
+    url = "jdbc:mysql://$mysql_ip_addr:3306/tradedb"
     print "mysql url: $url"    
     
 	user = 'mariadb'

--- a/web-ui/web-gateway/build.gradle
+++ b/web-ui/web-gateway/build.gradle
@@ -62,12 +62,12 @@ task updateVersion << {
     def workspace = env.WORKSPACE
 
     if (!workspace?.trim()){
-        workspace = ".."
+        workspace = "../.."
     }
 
     def version = getVersion()
     println "[updateVersion]version= $version"
-    def app_yml = String.format("%s/%s/src/main/resources/application.yml", workspace, jar.baseName)
+    def app_yml = String.format("%s/web-ui/%s/src/main/resources/application.yml", workspace, jar.baseName)
     String contents = new File(app_yml).getText("UTF-8")
 
     contents = contents.replaceAll('%%VERSION%%', version)


### PR DESCRIPTION
增加 continuous-deploy.sh 脚本，以及 infrastructure-cd.yml 和 application-cd.yml 用于持续部署的 docker-compose 配置。根据实际需要修改了部分配置文件和脚本。

在jenkins中，执行完 commit-build 之后，会自动调用 deploy 任务，deploy任务会调用 continuous-deploy.sh 进行将最新的发布自动部署在本机上。